### PR TITLE
Add documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 [![Latest Stable Version](https://poser.pugx.org/cubear/cwd_base/v/stable)](https://packagist.org/packages/cubear/cwd_base)
 [![Latest Unstable Version](https://poser.pugx.org/cubear/cwd_base/v/unstable)](https://packagist.org/packages/cubear/cwd_base)
 
- # cwd_base
+# cwd_base
 
 Can be used with https://github.com/CU-CommunityApps/cubear-starter-kit
 
 **See also:** https://github.com/CU-CommunityApps/cwd-design
 
 **See also:** SASS instructions over here: https://github.com/CU-CommunityApps/cwd_base_bootstrap
+
+
+## Documentation by Example
+
+https://iws-preview.hosting.cornell.edu/ama39/cssf/


### PR DESCRIPTION
Seems like we could link to the preview site to provide documentation?

The readme links to some other things that should maybe also be updated to reflect what is currently recommended?