### PR TITLE
jQuery ui easing

### DIFF
--- a/cwd_base.libraries.yml
+++ b/cwd_base.libraries.yml
@@ -29,3 +29,4 @@ header-scripts:
   dependencies:
     - core/jquery
     - core/jquery.ui
+    - core/jquery.ui.effects.core


### PR DESCRIPTION
The core.libraries apparently don't include jQuery effects if you include core/jquery.ui. So easing functions were failing. This fixes it.

### Review Steps
- [ ] Static analysis of code
