### PR TITLE
New "include" for field templates for image/video embed field types

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,30 @@ Included with https://github.com/CU-CommunityApps/CD-demo
 **See also:** SASS instructions over here: https://github.com/CU-CommunityApps/cwd_base_bootstrap
 
 NOTE: When using with a site created from [CD Demo](https://github.com/CU-CommunityApps/CD-demo), it's recommended to change the version constraint to exact version you're using when you get to site launch (or during development, if you prefer), so that the base theme doesn't get automatically updated with other packages.  (You can always update it "manually" by increasing the version constraint when you wish.)
+
+## Misc notes (to organize "later")
+
+### Template overrides hint:
+Original/Source templates have all sorts of variable info and other details.  For example, let's say you have a template called field--field-slider-media.html.twig -- that's a template specifically for field_slider_media.  If you want to find the original/source template that's being overridden by this template, look in the template docblock for notes like:
+`override field.html.twig`
+and/or
+`@see field.html.twig`
+^^ So, look for a template called field.html.twig to find out about variables and other details available to you in this specific field template.
+
+**Where to look?**  Surprise: It depends!  Some places to look: core/themes/stable/templates, core/modules/MODULENAME/templates, modules/contrib/MODULENAME/templates
+
+If the template you're looking at doesn't have the aforementioned notes (or a docblock at all), it's trickier to figure out.  If you're in a dev environment with [twig_debug enabled](https://www.drupal.org/docs/8/theming/twig/debugging-twig-templates#s-enable-debugging), you may find some clues in by viewing the page source -- look for HTML comments like this:
+```
+<!-- THEME DEBUG -->
+<!-- THEME HOOK: 'field' -->
+<!-- FILE NAME SUGGESTIONS:
+   * field--node--title--page.html.twig
+   x field--node--title.html.twig
+   * field--node--page.html.twig
+   * field--title.html.twig
+   * field--string.html.twig
+   * field.html.twig
+-->
+<!-- BEGIN OUTPUT from 'themes/custom/cwd_base/templates/field--node--title.html.twig' -->
+```
+^^ The "file name suggestions" are listed from [most specific to least specific](https://www.drupal.org/docs/8/theming/twig/locating-template-files-with-debugging), so, the last line of the suggestions list is the name of the "original/source" template is called -- then you can hunt around for the original version with variables, etc.

--- a/templates/field--node--body.html.twig
+++ b/templates/field--node--body.html.twig
@@ -1,27 +1,7 @@
 {#
 /**
  * @file
- * Theme override for the node body field.
- * ~ Removed unnecessary markup (ama39)
- *
- * This is an override of field.html.twig for the node body field. See that
- * template for documentation about its details and overrides.
- *
- * Available variables:
- * - attributes: HTML attributes for the containing span element.
- * - items: List of all the field items. Each item contains:
- *   - attributes: List of HTML attributes for each item.
- *   - content: The field item content.
- * - entity_type: The entity type to which the field belongs.
- * - field_name: The name of the field.
- * - field_type: The type of the field.
- * - label_display: The display settings for the label.
- *
- * @see field.html.twig
- *
- * @ingroup themeable
+ * Theme override for the node body field (any ctype).
  */
 #}
-{%- for item in items -%}
-  {{ item.content }}
-{%- endfor -%}
+{% include "@cwd_base/includes/_field--un-wrapped.html.twig" %}

--- a/templates/field--node--title.html.twig
+++ b/templates/field--node--title.html.twig
@@ -1,27 +1,7 @@
 {#
 /**
  * @file
- * Theme override for the node title field.
- * ~ Removed unnecessary markup (ama39)
- *
- * This is an override of field.html.twig for the node title field. See that
- * template for documentation about its details and overrides.
- *
- * Available variables:
- * - attributes: HTML attributes for the containing span element.
- * - items: List of all the field items. Each item contains:
- *   - attributes: List of HTML attributes for each item.
- *   - content: The field item content.
- * - entity_type: The entity type to which the field belongs.
- * - field_name: The name of the field.
- * - field_type: The type of the field.
- * - label_display: The display settings for the label.
- *
- * @see field.html.twig
- *
- * @ingroup themeable
+ * Theme override for the node title field (any ctype).
  */
 #}
-{%- for item in items -%}
-  {{ item.content }}
-{%- endfor -%}
+{% include "@cwd_base/includes/_field--un-wrapped.html.twig" %}

--- a/templates/includes/_field--less-wrapped.html.twig
+++ b/templates/includes/_field--less-wrapped.html.twig
@@ -2,7 +2,7 @@
 /**
  * @file
  * An include to override field.html.twig.
- * ~ Removed <div{{ attributes }}> from multiple section.
+ * ~ From label_hidden section, removed <div{{ attributes }}>, "multiple" check.
  * ~ Removed all <div{{ item.attributes }}> wrappers.
  * ~ Removed title_classes.
  *
@@ -26,15 +26,9 @@
  */
 #}
 {% if label_hidden %}
-  {% if multiple %}
-    {% for item in items %}
-      {{ item.content }}
-    {% endfor %}
-  {% else %}
-    {% for item in items %}
-      {{ item.content }}
-    {% endfor %}
-  {% endif %}
+  {% for item in items %}
+    {{ item.content }}
+  {% endfor %}
 {% else %}
   <div{{ attributes }}>
     <div{{ title_attributes }}>{{ label }}</div>

--- a/templates/includes/_field--less-wrapped.html.twig
+++ b/templates/includes/_field--less-wrapped.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * An include to override image and video embed field templates.
+ * An include to override field.html.twig.
  * ~ Removed <div{{ attributes }}> from multiple section.
  * ~ Removed all <div{{ item.attributes }}> wrappers.
  * ~ Removed title_classes.
@@ -25,7 +25,6 @@
  * @see template_preprocess_field()
  */
 #}
-
 {% if label_hidden %}
   {% if multiple %}
     {% for item in items %}

--- a/templates/includes/_field--un-wrapped.html.twig
+++ b/templates/includes/_field--un-wrapped.html.twig
@@ -1,0 +1,25 @@
+{#
+/**
+ * @file
+ * An include to override field.html.twig.
+ * ~ Remove all wrappers.
+ * ~ Remove label.
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing span element.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see field.html.twig
+ *
+ * @ingroup themeable
+ */
+#}
+{%- for item in items -%}
+  {{ item.content }}
+{%- endfor -%}

--- a/templates/includes/incl--field--image-video-embed.html.twig
+++ b/templates/includes/incl--field--image-video-embed.html.twig
@@ -23,8 +23,6 @@
  * @see field.html.twig
  *
  * @see template_preprocess_field()
- *
- * TO DO: get this (and the updated field--image and the new field--video-embed-field) into cwd_base and then remove all three from cwd_biotech!
  */
 #}
 

--- a/templates/includes/incl--field--image-video-embed.html.twig
+++ b/templates/includes/incl--field--image-video-embed.html.twig
@@ -1,0 +1,54 @@
+{#
+/**
+ * @file
+ * An include to override image and video embed field templates.
+ * ~ Removed <div{{ attributes }}> from multiple section.
+ * ~ Removed all <div{{ item.attributes }}> wrappers.
+ * ~ Removed title_classes.
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see field.html.twig
+ *
+ * @see template_preprocess_field()
+ *
+ * TO DO: get this (and the updated field--image and the new field--video-embed-field) into cwd_base and then remove all three from cwd_biotech!
+ */
+#}
+
+{% if label_hidden %}
+  {% if multiple %}
+    {% for item in items %}
+      {{ item.content }}
+    {% endfor %}
+  {% else %}
+    {% for item in items %}
+      {{ item.content }}
+    {% endfor %}
+  {% endif %}
+{% else %}
+  <div{{ attributes }}>
+    <div{{ title_attributes }}>{{ label }}</div>
+    {% if multiple %}
+      <div>
+    {% endif %}
+    {% for item in items %}
+      {{ item.content }}
+    {% endfor %}
+    {% if multiple %}
+      </div>
+    {% endif %}
+  </div>
+{% endif %}

--- a/templates/media/field--image.html.twig
+++ b/templates/media/field--image.html.twig
@@ -5,4 +5,4 @@
  */
 #}
 
-{% include "@cwd_biotech/includes/incl--field--image-video-embed.html.twig" %}
+{% include "@cwd_base/includes/incl--field--image-video-embed.html.twig" %}

--- a/templates/media/field--image.html.twig
+++ b/templates/media/field--image.html.twig
@@ -1,8 +1,7 @@
 {#
 /**
  * @file
- * Theme override for all fields of type "image" (any etypes/bundles).
+ * Theme override for all fields of type "image" (any etype/bundle).
  */
 #}
-
-{% include "@cwd_base/includes/incl--field--image-video-embed.html.twig" %}
+{% include "@cwd_base/includes/_field--less-wrapped.html.twig" %}

--- a/templates/media/field--video-embed-field.html.twig
+++ b/templates/media/field--video-embed-field.html.twig
@@ -5,4 +5,4 @@
  */
 #}
 
-{% include "@cwd_biotech/includes/incl--field--image-video-embed.html.twig" %}
+{% include "@cwd_base/includes/incl--field--image-video-embed.html.twig" %}

--- a/templates/media/field--video-embed-field.html.twig
+++ b/templates/media/field--video-embed-field.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override for all fields of type "image" (any etypes/bundles).
+ * Theme override for all fields of type "video_embed_field" (any etypes/bundles).
  */
 #}
 

--- a/templates/media/field--video-embed-field.html.twig
+++ b/templates/media/field--video-embed-field.html.twig
@@ -1,8 +1,7 @@
 {#
 /**
  * @file
- * Theme override for all fields of type "video_embed_field" (any etypes/bundles).
+ * Theme override for all fields of type "video_embed_field" (any etype/bundle).
  */
 #}
-
-{% include "@cwd_base/includes/incl--field--image-video-embed.html.twig" %}
+{% include "@cwd_base/includes/_field--less-wrapped.html.twig" %}


### PR DESCRIPTION
New "include" for image/video embed field types, based on existing field--image twig template.
Updated field--image and added field--video-embed-field to use the new include.