### PR TITLE
Gallery on basic page

### DIFF
--- a/templates/gallery/node--gallery.html.twig
+++ b/templates/gallery/node--gallery.html.twig
@@ -11,6 +11,11 @@
 {####### varrrriabllllles #######}
 
 {% set has_body, has_glitems, has_meta, has_svc, has_tags = false, false, false, false, false %}
+{% set galbod = {} %}
+{% set gallery_type_class = 'viewer' %}
+{% set glitems = [] %}
+{% set glervice = [] %}
+{% set glags = [] %}
 {% if node.field_service_term is defined and node.field_service_term is not empty %}
   {% set has_svc = true %}
   {% for key, value in node.field_service_term %}

--- a/templates/gallery/node--gallery.html.twig
+++ b/templates/gallery/node--gallery.html.twig
@@ -10,29 +10,10 @@
 
 {####### varrrriabllllles #######}
 
-{% set has_body, has_glitems, has_meta, has_svc, has_tags = false, false, false, false, false %}
+{% set has_body, has_glitems = false, false %}
 {% set galbod = {} %}
 {% set gallery_type_class = 'viewer' %}
 {% set glitems = [] %}
-{% set glervice = [] %}
-{% set glags = [] %}
-{% if node.field_service_term is defined and node.field_service_term is not empty %}
-  {% set has_svc = true %}
-  {% for key, value in node.field_service_term %}
-    {% set glervice = glervice|merge([node.field_service_term[key].entity.name.value]) %}
-  {% endfor %}
-{% endif %}
-
-{% if node.field_tags is defined and node.field_tags is not empty %}
-  {% set has_tags = true %}
-  {% for key, value in node.field_tags %}
-    {% set glags = glags|merge([node.field_tags[key].entity.name.value]) %}
-  {% endfor %}
-{% endif %}
-
-{% if has_svc or has_tags %}
-  {% set has_meta = true %}
-{% endif %}
 
 {% if node.field_gallery_type.value == 1 %}
   {% set gallery_type_class = 'grid' %}
@@ -83,29 +64,7 @@
       <a href="{{ url }}" rel="bookmark">{{- label -}}</a>
     </h2>
     {{ title_suffix }}
-
-  {% else -%} {# "if vm == full" #}
-
-    {% if has_meta == true -%}
-      <div class="group-meta field-group metadata-set">
-        {% if has_svc == true -%}
-          {% for key, value in glervice %}
-            <div class="field field-name-field-service-term">
-              <span class="deco">{{- value -}}</span>
-            </div>
-          {% endfor %}
-        {%- endif %}
-        {% if has_tags == true -%}
-          {% for key, value in glags %}
-            <div class="field field-name-field-tags">
-              <span class="deco">{{- value -}}</span>
-            </div>
-          {% endfor %}
-        {%- endif %}
-      </div>
-    {%- endif %}
-
-  {%- endif %} {# "if vm not full" != true #}
+  {%- endif %}
 
   {% if has_glitems == true -%}
     <div class="cwd-gallery strips {{ gallery_type_class }}" role="region" aria-label="Image Gallery">

--- a/templates/gallery/node--gallery.html.twig
+++ b/templates/gallery/node--gallery.html.twig
@@ -78,9 +78,9 @@
             {%- endif %}
             <div class="col">
               <a role="img" href="{{ file_url(glitems[key].gurl) }}" data-title="{{ glitems[key].gitle }}" data-alt="{{ glitems[key].galt }}" aria-label="{{ glitems[key].galt }}{{ title_aria_bridge }}{{ glitems[key].gitle }}">
-              {% if glitems[key].gitle %}
+              {% if glitems[key].gitle -%}
                 <h3 class="sr-only">{{- glitems[key].gitle -}}</h3>
-              {% endif %}
+              {%- endif %}
               <img src="{{ glitems[key].glimg_uri | image_style('gallery_thumbnail') }}" alt="{{ glitems[key].galt }}">
               </a>
             </div>

--- a/templates/gallery/node--gallery.html.twig
+++ b/templates/gallery/node--gallery.html.twig
@@ -1,87 +1,16 @@
 {#
 /**
  * @file
- * Default theme implementation to display a node.
+ * Theme override to display a gallery node.
+ * See cwd_base/node.html.twig for available variables and other info.
  *
- * Available variables:
- * - node: The node entity with limited access to object properties and methods.
- *   Only method names starting with "get", "has", or "is" and a few common
- *   methods such as "id", "label", and "bundle" are available. For example:
- *   - node.getCreatedTime() will return the node creation timestamp.
- *   - node.hasField('field_example') returns TRUE if the node bundle includes
- *     field_example. (This does not indicate the presence of a value in this
- *     field.)
- *   - node.isPublished() will return whether the node is published or not.
- *   Calling other methods, such as node.delete(), will result in an exception.
- *   See \Drupal\node\Entity\Node for a full list of public properties and
- *   methods for the node object.
- * - label: The title of the node.
- * - content: All node items. Use {{ content }} to print them all,
- *   or print a subset such as {{ content.field_example }}. Use
- *   {{ content|without('field_example') }} to temporarily suppress the printing
- *   of a given child element.
- * - author_picture: The node author user entity, rendered using the "compact"
- *   view mode.
- * - metadata: Metadata for this node.
- * - date: Themed creation date field.
- * - author_name: Themed author name field.
- * - url: Direct URL of the current node.
- * - display_submitted: Whether submission information should be displayed.
- * - attributes: HTML attributes for the containing element.
- *   The attributes.class element may contain one or more of the following
- *   classes:
- *   - node: The current template type (also known as a "theming hook").
- *   - node--type-[type]: The current node type. For example, if the node is an
- *     "Article" it would result in "node--type-article". Note that the machine
- *     name will often be in a short form of the human readable label.
- *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
- *     teaser would result in: "node--view-mode-teaser", and
- *     full: "node--view-mode-full".
- *   The following are controlled through the node publishing options.
- *   - node--promoted: Appears on nodes promoted to the front page.
- *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
- *     teaser listings.
- *   - node--unpublished: Appears on unpublished nodes visible only to site
- *     admins.
- * - title_attributes: Same as attributes, except applied to the main title
- *   tag that appears in the template.
- * - content_attributes: Same as attributes, except applied to the main
- *   content tag that appears in the template.
- * - author_attributes: Same as attributes, except applied to the author of
- *   the node tag that appears in the template.
- * - title_prefix: Additional output populated by modules, intended to be
- *   displayed in front of the main title tag that appears in the template.
- * - title_suffix: Additional output populated by modules, intended to be
- *   displayed after the main title tag that appears in the template.
- * - view_mode: View mode; for example, "teaser" or "full".
- * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
- * - page: Flag for the full page state. Will be true if view_mode is 'full'.
- * - readmore: Flag for more state. Will be true if the teaser content of the
- *   node cannot hold the main body content.
- * - logged_in: Flag for authenticated user status. Will be true when the
- *   current user is a logged-in member.
- * - is_admin: Flag for admin user status. Will be true when the current user
- *   is an administrator.
- *
- * @see template_preprocess_node()
- *
- * @todo Remove the id attribute (or make it a class), because if that gets
- *   rendered twice on a page this is invalid CSS for example: two lists
- *   in different view modes.
- *
- * @ingroup themeable
+ * @see template_preprocess_html()
  */
 #}
 
 {####### varrrriabllllles #######}
 
 {% set has_body, has_glitems, has_meta, has_svc, has_tags = false, false, false, false, false %}
-{% set galbod = {} %}
-{% set gallery_type_class = 'viewer' %}
-{% set glitems = [] %}
-{% set glervice = [] %}
-{% set glags = [] %}
-
 {% if node.field_service_term is defined and node.field_service_term is not empty %}
   {% set has_svc = true %}
   {% for key, value in node.field_service_term %}
@@ -143,50 +72,50 @@
 
 <article{{ attributes }}>
 
-  {% if view_mode != 'full' %}
-  {{ title_prefix }}
+  {% if view_mode != 'full' -%}
+    {{ title_prefix }}
     <h2{{ title_attributes }}>
-      <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+      <a href="{{ url }}" rel="bookmark">{{- label -}}</a>
     </h2>
-  {{ title_suffix }}
+    {{ title_suffix }}
 
-  {% else %} {# "if vm == full" #}
+  {% else -%} {# "if vm == full" #}
 
-  {% if has_meta == true %}
-    <div class="group-meta field-group metadata-set">
-      {% if has_svc == true %}
-        {% for key, value in glervice %}
-          <div class="field field-name-field-service-term">
-            <span class="deco">{{ value }}</span>
-          </div>
-        {% endfor %}
-      {% endif %}
-      {% if has_tags == true %}
-        {% for key, value in glags %}
-          <div class="field field-name-field-tags">
-            <span class="deco">{{ value }}</span>
-          </div>
-        {% endfor %}
-      {% endif %}
-    </div>
-  {% endif %}
+    {% if has_meta == true -%}
+      <div class="group-meta field-group metadata-set">
+        {% if has_svc == true -%}
+          {% for key, value in glervice %}
+            <div class="field field-name-field-service-term">
+              <span class="deco">{{- value -}}</span>
+            </div>
+          {% endfor %}
+        {%- endif %}
+        {% if has_tags == true -%}
+          {% for key, value in glags %}
+            <div class="field field-name-field-tags">
+              <span class="deco">{{- value -}}</span>
+            </div>
+          {% endfor %}
+        {%- endif %}
+      </div>
+    {%- endif %}
 
-  {% endif %} {# "if vm == full" #}
+  {%- endif %} {# "if vm not full" != true #}
 
-  {% if has_glitems == true %}
+  {% if has_glitems == true -%}
     <div class="cwd-gallery strips {{ gallery_type_class }}" role="region" aria-label="Image Gallery">
-      {% if gallery_type_class == 'viewer' %}<div class="slide" role="presentation"></div>{% endif %}
+      {% if gallery_type_class == 'viewer' -%}<div class="slide" role="presentation"></div>{%- endif %}
       <div class="thumbnails-band">
         <div class="thumbnails flex">
           {% for key, value in glitems %}
             {% set title_aria_bridge = '' %}
-            {% if glitems[key].gitle %}
+            {% if glitems[key].gitle -%}
               {% set title_aria_bridge = ', Caption: ' %}
-            {% endif %}
+            {%- endif %}
             <div class="col">
               <a role="img" href="{{ file_url(glitems[key].gurl) }}" data-title="{{ glitems[key].gitle }}" data-alt="{{ glitems[key].galt }}" aria-label="{{ glitems[key].galt }}{{ title_aria_bridge }}{{ glitems[key].gitle }}">
               {% if glitems[key].gitle %}
-                <h3 class="sr-only">{{ glitems[key].gitle }}</h3>
+                <h3 class="sr-only">{{- glitems[key].gitle -}}</h3>
               {% endif %}
               <img src="{{ glitems[key].glimg_uri | image_style('gallery_thumbnail') }}" alt="{{ glitems[key].galt }}">
               </a>
@@ -195,13 +124,13 @@
         </div>
       </div>
     </div>
-  {% endif %}
+  {%- endif %}
 
-  {% if view_mode == 'full' %}
-    {% if has_body == true %}
+  {% if view_mode == 'full' -%}
+    {% if has_body == true -%}
       <hr class="section-break">
-      {{ content.body }}
-    {% endif %}
-  {% endif %}
+      {{ node.body|view }}
+    {%- endif %}
+  {%- endif %}
 
 </article>

--- a/templates/gallery/node--gallery.html.twig
+++ b/templates/gallery/node--gallery.html.twig
@@ -150,9 +150,7 @@
     </h2>
   {{ title_suffix }}
 
-  {{ content }}
-
-  {% else %} {# "if vm not full" != true #}
+  {% else %} {# "if vm == full" #}
 
   {% if has_meta == true %}
     <div class="group-meta field-group metadata-set">
@@ -172,6 +170,8 @@
       {% endif %}
     </div>
   {% endif %}
+
+  {% endif %} {# "if vm == full" #}
 
   {% if has_glitems == true %}
     <div class="cwd-gallery strips {{ gallery_type_class }}" role="region" aria-label="Image Gallery">
@@ -197,10 +197,11 @@
     </div>
   {% endif %}
 
-  {% if has_body == true %}
-    <hr class="section-break">
-    {{ content.body }}
+  {% if view_mode == 'full' %}
+    {% if has_body == true %}
+      <hr class="section-break">
+      {{ content.body }}
+    {% endif %}
   {% endif %}
 
-  {% endif %} {# "if vm not full" != true #}
 </article>


### PR DESCRIPTION
Addresses `#4` on https://github.com/CU-CommunityApps/CD-demo/issues/93

(also removes code related to metadata fields that don't exist on CD Demo -- they were there from when the template was copied in from the CTI site)