### PR TITLE
support adding a SR-only heading to views

### DIFF
--- a/templates/includes/partial--view-sr-heading.html.twig
+++ b/templates/includes/partial--view-sr-heading.html.twig
@@ -1,0 +1,10 @@
+{#
+/**
+ * For use with views-view "view_sr_heading" block.
+ *
+ * Is this an excessive use of partial/include templates? YA IT MIGHT BE!! ...here's the thing: I'm repeating something four times, so it feels WRONG not to use an include.
+ * Is there a more elegant solution? MAYBE!! DO YOU KNOW ONE?? NO?? K, LEEMEALONE. ...here's the thing: I'm already spending too much time on this, and Eric isn't free, and it's nighttime, so I'm goin' with it.
+ * All that said... There will be a PR on CD Demo (er, cwd_base), and I'll raise these questions. Now leave me alone.
+ */
+#}
+<h2 class="sr-only">Full listing</h2>

--- a/templates/views-view.html.twig
+++ b/templates/views-view.html.twig
@@ -2,7 +2,6 @@
 /**
  * @file
  * Theme override for main view template.
- * Includes some elements from classy/templates/views/views-view.html.twig #teamD7
  *
  * Available variables:
  * - attributes: Remaining HTML attributes for the element.
@@ -61,6 +60,8 @@
 
 
   {% if rows %}
+    {% block view_sr_heading %}
+    {% endblock %}
     <div class="view-content cards">
       {{ rows }}
     </div>


### PR DESCRIPTION
...right before div.view-content.cards -- and add a partial template for the most common implementation of said heading

Related framework documentation: https://iws-preview.hosting.cornell.edu/ama39/cssf/patterns.html
(^^ "...Note: Typically, the view or block heading is an H2...")

_[cwd_project PR #16](https://github.com/CU-CommunityApps/cwd_project/pull/16) depends on this cwd_base PR_

----
### See it in action
https://test-cbb.pantheonsite.io/spotlights
Example of it working fine / not breaking when there are no results, in case you're worried like I was: https://test-cbb.pantheonsite.io/spotlights?spotlight-category-tid=7
